### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     working_directory: ~/breakpirates-v3
     machine:
-      image: ubuntu-2004:202101-01
+      image: cimg/base:2022.11
     steps:
       # Checkout the code from the branch into the working_directory
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     working_directory: ~/breakpirates-v3
     machine:
-      image: cimg/base:2022.11
+      image: ubuntu-2004:2022.10.1
     steps:
       # Checkout the code from the branch into the working_directory
       - checkout


### PR DESCRIPTION
Testing new Circle CI image as latest Angular CLI isn't compatible with the `ubuntu-2004:202101-01` one.